### PR TITLE
`update_event_sources` fails on SNS and S3 event sources

### DIFF
--- a/kappa/event_source.py
+++ b/kappa/event_source.py
@@ -132,16 +132,21 @@ class S3EventSource(EventSource):
 
     def add(self, function):
         notification_spec = {
-            'CloudFunctionConfiguration': {
-                'Id': self._make_notification_id(function.name),
-                'Events': [e for e in self._config['events']],
-                'CloudFunction': function.arn}}
+            'LambdaFunctionConfigurations':[
+                {
+                    'Id': self._make_notification_id(function.name),
+                    'Events': [e for e in self._config['events']],
+                    'LambdaFunctionArn': function.arn,
+                }
+            ]
+        }
         try:
-            response = self._s3.put_bucket_notification(
+            response = self._s3.put_bucket_notification_configuration(
                 Bucket=self._get_bucket_name(),
                 NotificationConfiguration=notification_spec)
             LOG.debug(response)
-        except Exception:
+        except Exception as exc:
+            LOG.debug(exc.response)
             LOG.exception('Unable to add S3 event source')
 
     def update(self, function):

--- a/kappa/event_source.py
+++ b/kappa/event_source.py
@@ -144,6 +144,9 @@ class S3EventSource(EventSource):
         except Exception:
             LOG.exception('Unable to add S3 event source')
 
+    def update(self, function):
+        self.add(function)
+
     def remove(self, function):
         LOG.debug('removing s3 notification')
         response = self._s3.get_bucket_notification(
@@ -199,6 +202,9 @@ class SNSEventSource(EventSource):
             LOG.debug(response)
         except Exception:
             LOG.exception('Unable to add SNS event source')
+
+    def update(self, function):
+        self.add(function)
 
     def remove(self, function):
         LOG.debug('removing SNS event source')


### PR DESCRIPTION
Per #32, add an update method for event sources that don't have them.