### PR TITLE
add dependencies and check for existing key in zip before writing new…

### DIFF
--- a/kappa/context.py
+++ b/kappa/context.py
@@ -57,7 +57,7 @@ class Context(object):
         self.function = kappa.function.Function(
             self, self.config['lambda'])
         if 'restapi' in self.config:
-            self.restapi = kappa.restapi.RestApi(
+            self.restapi = RestApi(
                 self, self.config['restapi'])
         else:
             self.restapi = None

--- a/kappa/context.py
+++ b/kappa/context.py
@@ -57,7 +57,7 @@ class Context(object):
         self.function = kappa.function.Function(
             self, self.config['lambda'])
         if 'restapi' in self.config:
-            self.restapi = RestApi(
+            self.restapi = kappa.restapi.RestApi(
                 self, self.config['restapi'])
         else:
             self.restapi = None


### PR DESCRIPTION
… file.

This feature add a  "dependencies" parameter to the "lambda" configuration. This parameters consist of a list of resources to add to the zip file. As an exemple, here is how I use it : 
```
lambda:
  name: testKappaDeployer
  description: Testing kappa
  dependencies:
    - transformer.py
    - table_definitions.py
    - core.py
    - formatter.py
    - ami_built_modules
    - venv/lib/python2.7/site-packages
  handler: loader.lambda_handler
  runtime: python2.7
  memory_size: 128
  timeout: 3
  test_data: test/simpleS3test.json
```