### PR TITLE
S3 Event Source Status fix

### DIFF
--- a/kappa/event_source/s3.py
+++ b/kappa/event_source/s3.py
@@ -92,5 +92,8 @@ class S3EventSource(kappa.event_source.base.EventSource):
             Bucket=self._get_bucket_name())
         LOG.debug(response)
         if 'CloudFunctionConfiguration' not in response:
-            response = None
-        return response
+            return None
+        return {
+            'EventSourceArn': response['CloudFunctionConfiguration']['CloudFunction'],
+            'State': 'Enabled'
+        }


### PR DESCRIPTION
The CLI expects to see `EventSourceArn` and `State` in the result from the `status` method in each event_source. This makes it work for the S3 event sources