### PR TITLE
Fix for the config file example

### DIFF
--- a/docs/config_file_example.rst
+++ b/docs/config_file_example.rst
@@ -11,8 +11,8 @@ Example
 
 Here is an example config file showing all possible sections.
 
-.. sourcecode:: yaml
-    :linenos:
+.. code:: yaml
+    :number-lines:
 
     ---
     name: kappa-python-sample
@@ -61,7 +61,7 @@ Here is an example config file showing all possible sections.
         subnet_ids:
           - subnet-12345678
           - subnet-23456789
-          
+
 
 Explanations:
 


### PR DESCRIPTION
The config file example at: https://github.com/garnaat/kappa/blob/develop/docs/config_file_example.rst doesn't actually show the config file as the formatting is wrong and Github just ignores it.

Github doesn't seem to support `sourcecode` blocks ... instead they're
called `code`, see http://docutils.sourceforge.net/docs/ref/rst/directives.html#code
