### PR TITLE
LambdaFunctionArn shouldn't be suffixed with the environment in the S3 event source

### DIFF
--- a/kappa/event_source/s3.py
+++ b/kappa/event_source/s3.py
@@ -37,7 +37,7 @@ class S3EventSource(kappa.event_source.base.EventSource):
                 {
                     'Id': self._make_notification_id(function.name),
                     'Events': [e for e in self._config['events']],
-                    'LambdaFunctionArn': '%s:%s' % (function.arn, function._context.environment),
+                    'LambdaFunctionArn': function.arn,
                 }
             ]
         }


### PR DESCRIPTION
When configuring the S3 bucket event the function `add` builds the `LambdaFunctionConfigurations` which specifies the `LambdaFunctionArn`. The ARN should be the functions *exact* ARN and not suffixed by the environment ex.`arn:aws:lambda:us-west-1:1234567890123:function:bigquery_commit:main-env`.

It makes the Lambda UI and the S3 event sources UI confused as they don't recognize that the specific Lambda function even exists.

The reason why I made this change is because I had problems applying the bucket event cross-account and could not do this without this change.

Update: ok I see that anything that comes after the function ARN is a version and/or alias http://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases-permissions.html ... just means that the UI can't handle these

Comments about this?