### PR TITLE
Adding fix for issue 85,87,88,89,90

### DIFF
--- a/kappa/event_source/cloudwatch.py
+++ b/kappa/event_source/cloudwatch.py
@@ -72,6 +72,8 @@ class CloudWatchEventSource(kappa.event_source.base.EventSource):
                                              Principal='events.amazonaws.com',
                                              SourceArn=self._config['arn'])
                 LOG.debug(response)
+            else:
+                LOG.debug('CloudWatch event source permission already exists')
             response = self._events.call('put_targets',
                                          Rule=self._name,
                                          Targets=[{

--- a/kappa/event_source/cloudwatch.py
+++ b/kappa/event_source/cloudwatch.py
@@ -56,13 +56,22 @@ class CloudWatchEventSource(kappa.event_source.base.EventSource):
             response = self._events.call('put_rule', **kwargs)
             LOG.debug(response)
             self._config['arn'] = response['RuleArn']
-            response = self._lambda.call('add_permission',
-                                         FunctionName=function.name,
-                                         StatementId=str(uuid.uuid4()),
-                                         Action='lambda:InvokeFunction',
-                                         Principal='events.amazonaws.com',
-                                         SourceArn=response['RuleArn'])
-            LOG.debug(response)
+            existingPermission={}
+            try:
+                response = self._lambda.call('get_policy',
+                                         FunctionName=function.name)
+                existingPermission = self._config['arn'] in str(response['Policy'])
+            except Exception:
+                LOG.debug('CloudWatch event source permission not available')
+
+            if not existingPermission:
+                response = self._lambda.call('add_permission',
+                                             FunctionName=function.name,
+                                             StatementId=str(uuid.uuid4()),
+                                             Action='lambda:InvokeFunction',
+                                             Principal='events.amazonaws.com',
+                                             SourceArn=self._config['arn'])
+                LOG.debug(response)
             response = self._events.call('put_targets',
                                          Rule=self._name,
                                          Targets=[{

--- a/kappa/event_source/s3.py
+++ b/kappa/event_source/s3.py
@@ -38,14 +38,14 @@ class S3EventSource(kappa.event_source.base.EventSource):
         existingPermission={}
         try:
             response = self._lambda.call('get_policy',
-                                     FunctionName='%s:%s' % (function.name, function._context.environment))
+                                     FunctionName=function.name)
             existingPermission = self.arn in str(response['Policy'])
         except Exception:
             LOG.debug('S3 event source permission not available')
 
         if not existingPermission:
             response = self._lambda.call('add_permission',
-                                         FunctionName='%s:%s' % (function.name, function._context.environment),
+                                         FunctionName=function.name,
                                          StatementId=str(uuid.uuid4()),
                                          Action='lambda:InvokeFunction',
                                          Principal='s3.amazonaws.com',
@@ -57,7 +57,7 @@ class S3EventSource(kappa.event_source.base.EventSource):
         new_notification_spec = {
             'Id': self._make_notification_id(function.name),
             'Events': [e for e in self._config['events']],
-            'LambdaFunctionArn': '%s:%s' % (function.arn, function._context.environment),
+            'LambdaFunctionArn': function.arn,
         }
 
         # Add S3 key filters


### PR DESCRIPTION
- [Updating cloudwatch event source causes trigger to show multiple times in AWS console](https://github.com/garnaat/kappa/issues/85)
- [S3 Event Source should add permission for S3 bucket to invoke function](https://github.com/garnaat/kappa/issues/87)
- [S3 Event Source put-bucket-notification-configuration call overwrites any pre-existing notification configuration](https://github.com/garnaat/kappa/issues/88)
- [S3 Event Source delete function not working as expected](https://github.com/garnaat/kappa/issues/89)
- [S3 Event Source status function not working as expected](https://github.com/garnaat/kappa/issues/90)