### PR TITLE
Allow deploys with existing role

### DIFF
--- a/kappa/context.py
+++ b/kappa/context.py
@@ -63,8 +63,11 @@ class Context(object):
         if recording_path:
             self.pill = placebo.attach(self.session, recording_path)
             self.pill.record()
-        self.policy = kappa.policy.Policy(
-            self, self.config['environments'][self.environment])
+        if self.config['environments'][self.environment].get('policy',None):
+            self.policy = kappa.policy.Policy(
+                self, self.config['environments'][self.environment])
+        else:
+            self.policy = None
         self.role = kappa.role.Role(
             self, self.config['environments'][self.environment])
         self.function = kappa.function.Function(

--- a/kappa/role.py
+++ b/kappa/role.py
@@ -46,10 +46,11 @@ class Role(object):
             self._iam_client = kappa.awsclient.create_client(
                 'iam', context.session)
         self._arn = None
+        self._config_name = config.get('role', None) and config['role'].get('name', None)
 
     @property
     def name(self):
-        return '{}_{}'.format(self._context.name, self._context.environment)
+        return self._config_name or '{}_{}'.format(self._context.name, self._context.environment)
 
     @property
     def arn(self):

--- a/samples/simple/kappa-existing-role.sample
+++ b/samples/simple/kappa-existing-role.sample
@@ -1,0 +1,16 @@
+---
+name: kappa-simple
+environments:
+  dev:
+    profile: <your profile here>
+    region: <your region here>
+    # Noo need to specify a policy since we are using an already existing role
+    role:
+      name: some-role-name
+
+lambda:
+  description: A very simple Kappa example
+  handler: simple.handler
+  runtime: python2.7
+  memory_size: 128
+  timeout: 3

--- a/tests/unit/test_role.py
+++ b/tests/unit/test_role.py
@@ -41,7 +41,7 @@ class TestRole(unittest.TestCase):
                                    self.context.environment),
             'Arn': randomword(10)
         }
-        self.role = Role(self.context, None, iam_client=self.iam_client)
+        self.role = Role(self.context, {'environments': {'dev': {}}}, iam_client=self.iam_client)
 
     def _expect_get_role(self):
         get_role_resp = {'Role': self.role_record}


### PR DESCRIPTION
This code allows deploying Lambda using an existing role (instead of creating a new one).

 * No policy needed
 * Use role name

Note: tried to update new test for this functionality, but got some problems (too deep recursion) on `placebo` package. Anyways, editing the foo/kappa.yml to use a role instead of a policy worked (tests passed).

A kappa.yml example would be:
```
---
name: kappa-simple
environments:
  dev:
    profile: foobar
    region: us-west-2
    role:
      name: foo-the-role
lambda:    
  description: Foo the Bar
  handler: simple.handler
  runtime: python2.7
  memory_size: 256
  timeout: 3
```