### PR TITLE
Added environment variable support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,9 @@ like this:
       dev:
         profile: <your profile here>
         region: <your region here>
+        environment_variables:
+          <key 1>: <value 1>
+          <key 2>: <value 2>
         policy:
           resources:
             - arn: arn:aws:logs:*:*:*
@@ -119,16 +122,16 @@ The ``environments`` section is where we define the different environments into
 which we wish to deploy this Lambda function.  Each environment is identified
 by a ``profile`` (as used in the AWS CLI and other AWS tools) and a
 ``region``.  You can define as many environments as you wish but each
-invocation of ``kappa`` will deal with a single environment.  Each environment
-section also includes a ``policy`` section.  This is where we tell kappa about
-AWS resources that our Lambda function needs access to and what kind of access
-it requires.  For example, your Lambda function may need to read from an SNS
-topic or write to a DynamoDB table and this is where you would provide the ARN
-(`Amazon Resource Name`_)
-that identify those resources.  Since this is a very simple example, the only
-resource listed here is for CloudWatch logs so that our Lambda function is able
-to write to the CloudWatch log group that will be created for it automatically
-by AWS Lambda.
+invocation of ``kappa`` will deal with a single environment.  An environment
+can optionally contain ``environment variables`` as key-value pairs.  Each
+environment section also includes a ``policy`` section.  This is where we tell
+kappa about AWS resources that our Lambda function needs access to and what
+kind of access it requires.  For example, your Lambda function may need to
+read from an SNS topic or write to a DynamoDB table and this is where you would
+provide the ARN (`Amazon Resource Name`_) that identifies those resources.
+Since this is a very simple example, the only resource listed here is for
+CloudWatch logs so that our Lambda function is able to write to the CloudWatch
+log group that will be created for it automatically by AWS Lambda.
 
 .. _`Amazon Resource Name`: http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 

--- a/docs/config_file_example.rst
+++ b/docs/config_file_example.rst
@@ -20,6 +20,9 @@ Here is an example config file showing all possible sections.
       env1:
         profile: profile1
         region: us-west-2
+        environment_variables:
+          key_one: "potatoes"
+          second_key: "Strawberries"
         policy:
           resources:
             - arn: arn:aws:dynamodb:us-west-2:123456789012:table/foo
@@ -78,20 +81,25 @@ Line Number    Description
 5              The profile name associated with this environment.  This
                refers to a profile in your AWS credential file.
 6              The AWS region associated with this environment.
-7              This section defines the elements of the IAM policy that will
+7              The environment_variables namespace is optional, but required
+               if you wish to specify any environment variable.
+               You may use any arbitrary value for the key or value
+               as long as both Python keyword argument syntax and the
+               AWS environment variable API restrictions are respected.
+10             This section defines the elements of the IAM policy that will
                be created for this function in this environment.
-9              Each resource your function needs access to needs to be
+12             Each resource your function needs access to needs to be
                listed here.  Provide the ARN of the resource as well as
                a list of actions.  This could be wildcarded to allow all
                actions but preferably should list the specific actions you
                want to allow.
-15             If your Lambda function has any event sources, this would be
+18             If your Lambda function has any event sources, this would be
                where you list them.  Here, the example shows a Kinesis
                stream but this could also be a DynamoDB stream, an SNS
                topic, or an S3 bucket.
-18             For Kinesis streams and DynamoDB streams, you can specify
+21             For Kinesis streams and DynamoDB streams, you can specify
                the starting position (one of LATEST or TRIM_HORIZON) and
                the batch size.
-35             This section contains settings specify to your Lambda
+38             This section contains settings specify to your Lambda
                function.  See the Lambda docs for details on these.
 ===========    =============================================================

--- a/kappa/context.py
+++ b/kappa/context.py
@@ -59,6 +59,9 @@ class Context(object):
 
         profile = self.config['environments'][self.environment]['profile']
         region = self.config['environments'][self.environment]['region']
+        if 'environment_variables' in (self.config['environments'][self.environment]):
+            self.environment_variables = self.config['environments'][self.environment]['environment_variables']
+
         self.session = kappa.awsclient.create_session(profile, region)
         if recording_path:
             self.pill = placebo.attach(self.session, recording_path)

--- a/kappa/function.py
+++ b/kappa/function.py
@@ -48,6 +48,16 @@ class Function(object):
         return self._context.name
 
     @property
+    def environment_variables(self):
+        try:
+            if (self._context.environment_variables is not None):
+                return {'Variables': self._context.environment_variables}
+        except AttributeError:
+            pass
+
+        return {'Variables': {}}
+
+    @property
     def runtime(self):
         return self._config['runtime']
 
@@ -192,6 +202,8 @@ class Function(object):
         m.update(self._context.exec_role_arn.encode('utf-8'))
         m.update(str(self.timeout).encode('utf-8'))
         m.update(str(self.vpc_config).encode('utf-8'))
+        m.update(str(self.environment_variables).encode('utf-8'))
+
         config_md5 = m.hexdigest()
         cached_md5 = self._context.get_cache_value('config_md5')
         LOG.debug('config_md5: %s', config_md5)
@@ -392,6 +404,7 @@ class Function(object):
                         Runtime=self.runtime,
                         Role=exec_role,
                         Handler=self.handler,
+                        Environment=self.environment_variables,
                         Description=self.description,
                         Timeout=self.timeout,
                         MemorySize=self.memory_size,
@@ -448,6 +461,7 @@ class Function(object):
                     VpcConfig=self.vpc_config,
                     Role=exec_role,
                     Handler=self.handler,
+                    Environment=self.environment_variables,
                     Description=self.description,
                     Timeout=self.timeout,
                     MemorySize=self.memory_size)

--- a/samples/simple/kappa.yml.sample
+++ b/samples/simple/kappa.yml.sample
@@ -4,6 +4,9 @@ environments:
   dev:
     profile: <your profile here>
     region: <your region here>
+    environment_variables:
+      key_one: "potatoes"
+      second_key: "Strawberries"
     policy:
       resources:
         - arn: arn:aws:logs:*:*:*
@@ -12,6 +15,7 @@ environments:
   prod:
     profile: <your profile here>
     region: <your region here>
+    environment_variables:
     policy:
       resources:
         - arn: arn:aws:logs:*:*:*


### PR DESCRIPTION
Hi, this pull request allows for environment variables to be used
At the environment level, if the environment_variables key is present with a dictionary, it will add it to the update_configuration and create methods. Otherwise, it will send blank data which effectively removes any existing environment variables

The _check_config_md5 method will also consider changes in the yml file, and will update lambda function configuration if any change is detected

I added an example to the kamma-simple project