### PR TITLE
Do not force profile for AWS session

### DIFF
--- a/kappa/awsclient.py
+++ b/kappa/awsclient.py
@@ -89,7 +89,7 @@ class AWSClient(object):
         return data
 
 
-def create_session(profile_name, region_name):
+def create_session(profile_name=None, region_name=None):
     global _session_cache
     session_key = '{}:{}'.format(profile_name, region_name)
     if session_key not in _session_cache:

--- a/kappa/context.py
+++ b/kappa/context.py
@@ -57,7 +57,7 @@ class Context(object):
             LOG.error(message)
             sys.exit(1)
 
-        profile = self.config['environments'][self.environment]['profile']
+        profile = self.config['environments'][self.environment].get('profile', None)
         region = self.config['environments'][self.environment]['region']
         self.session = kappa.awsclient.create_session(profile, region)
         if recording_path:

--- a/samples/simple/kappa-no-profile.yml.sample
+++ b/samples/simple/kappa-no-profile.yml.sample
@@ -1,0 +1,29 @@
+---
+name: kappa-simple
+environments:
+  dev:
+    # No need to specify profile, boto3 will pick it fron the running ENV
+    region: us-east-1
+    policy:
+      resources:
+        - arn: arn:aws:logs:*:*:*
+          actions:
+          - "*"
+    resources:
+      - arn: arn:aws:logs:*:*:*
+        actions:
+        - "*"
+  prod:
+    profile: <your profile here>
+    region: <your region here>
+    policy:
+      resources:
+        - arn: arn:aws:logs:*:*:*
+          actions:
+          - "*"
+lambda:
+  description: A very simple Kappa example
+  handler: simple.handler
+  runtime: python2.7
+  memory_size: 128
+  timeout: 3

--- a/tests/unit/foobar/kappa-no-profile.yml
+++ b/tests/unit/foobar/kappa-no-profile.yml
@@ -1,0 +1,16 @@
+---
+name: kappa-simple
+environments:
+  dev:
+    region: us-west-2
+    policy:
+      resources:
+        - arn: arn:aws:logs:*:*:*
+          actions:
+          - "*"
+lambda:
+  description: Foo the Bar
+  handler: simple.handler
+  runtime: python2.7
+  memory_size: 256
+  timeout: 3

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -52,3 +52,18 @@ class TestLog(unittest.TestCase):
         ctx = kappa.context.Context(cfg_fp, 'dev')
         ctx.deploy()
         ctx.deploy()
+
+
+    def test_deploy_no_profile(self):
+        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
+        self.session = kappa.awsclient.create_session(None, 'us-west-2')
+
+        pill = placebo.attach(self.session, self.data_path)
+        pill.playback()
+        os.chdir(self.prj_path)
+        cfg_filepath = os.path.join(self.prj_path, 'kappa-no-profile.yml')
+        cfg_fp = open(cfg_filepath)
+        ctx = kappa.context.Context(cfg_fp, 'dev')
+        ctx.deploy()
+        ctx.deploy()


### PR DESCRIPTION
 * Let boto3 handle credentials, do not force the use of profile

Tested deploy, tail and delete on a real account (besides the unittest with mocking/placebo)