### PR TITLE
Add excluded_dirs support, add s3transfer excluded_dirs, fix #93 #108

### DIFF
--- a/docs/config_file_example.rst
+++ b/docs/config_file_example.rst
@@ -58,6 +58,7 @@ Here is an example config file showing all possible sections.
       memory_size: 256
       timeout: 3
       log_retention_policy: 7
+      excluded_dirs: default
       vpc_config:
         security_group_ids:
           - sg-12345678
@@ -103,4 +104,10 @@ Line Number    Description
                the batch size.
 38             This section contains settings specify to your Lambda
                function.  See the Lambda docs for details on these.
+45             Kappa excludes directories from build-in libraries provided
+               by AWS Lambda from the upload zip file when `excluded_dirs`
+               is not specified or set to 'default'. When `excluded_dirs`
+               is set to 'none', kappa will exclude no directories.
+               Otherwise kappa will exclude directories specified when
+               `excluded_dirs` is set.
 ===========    =============================================================

--- a/kappa/function.py
+++ b/kappa/function.py
@@ -31,9 +31,9 @@ LOG = logging.getLogger(__name__)
 
 class Function(object):
 
-    excluded_dirs = ['boto3', 'botocore', 'concurrent', 'dateutil',
-                     'docutils', 'futures', 'jmespath', 'python_dateutil']
-    excluded_files = ['.gitignore']
+    DEFAULT_EXCLUDED_DIRS = ['boto3', 'botocore', 's3transfer', 'concurrent', 'dateutil', 'docutils', 'futures',
+                             'jmespath', 'python_dateutil']
+    DEFAULT_EXCLUDED_FILES = ['.gitignore']
 
     def __init__(self, context, config):
         self._context = context
@@ -96,6 +96,19 @@ class Function(object):
     @property
     def zipfile_name(self):
         return '{}.zip'.format(self._context.name)
+
+    @property
+    def excluded_dirs(self):
+        excluded_dirs = self._config.get('excluded_dirs', 'default')
+        if excluded_dirs == 'default':
+            excluded_dirs = self.DEFAULT_EXCLUDED_DIRS
+        elif excluded_dirs == 'none':
+            excluded_dirs = list()
+        return excluded_dirs
+
+    @property
+    def excluded_files(self):
+        return self._config.get('excluded_files', self.DEFAULT_EXCLUDED_FILES)
 
     @property
     def tests(self):
@@ -230,6 +243,7 @@ class Function(object):
     def _zip_lambda_dir(self, zipfile_name, lambda_dir):
         LOG.debug('_zip_lambda_dir: lambda_dir=%s', lambda_dir)
         LOG.debug('zipfile_name=%s', zipfile_name)
+        LOG.debug('excluded_dirs={}'.format(self.excluded_dirs))
         relroot = os.path.abspath(lambda_dir)
         with zipfile.ZipFile(zipfile_name, 'a',
                              compression=zipfile.ZIP_DEFLATED) as zf:


### PR DESCRIPTION
What changed:

1. new feature: 
`excluded_dirs` are now configurable. #93 

**Before**: kappa in-explicitly exclude directories generated by some libraries. Those libraries are typically provided by AWS Lambda environment. Examples includes boto, boto3 etc. 
**Now**: excluded_dirs are now configurable in kappa.yml, user can specify `default`, `none`, or a list of their own customized directories to be excluded. 
**Backward compatibility**: the change is backward compatible, if `excluded_dirs` are not configured, it is in `default` and excludes folders generated by libraries provided by AWS Lambda - same as before. 

2. bug fix:
s3transfer is one of the folders/libraries boto3 installs, but it were not included in the excluded folders, which causes compatibility issues when AWS Lambda updates its buildin libraries under the hood. #108 

