### PR TITLE
Fix update alias

### DIFF
--- a/kappa/function.py
+++ b/kappa/function.py
@@ -365,6 +365,12 @@ class Function(object):
                 FunctionVersion=version,
                 Name=name)
             LOG.debug(response)
+        except ClientError as e:
+            if 'ResourceNotFoundException' in str(e):
+                LOG.debug('Alias not found, creating it...')
+                self.create_alias(name, description, version)
+            else:
+                LOG.error('Unexpected error while update_alias: %s', e)
         except Exception:
             LOG.exception('Unable to update alias')
 
@@ -460,11 +466,11 @@ class Function(object):
                         ZipFile=zipdata,
                         Publish=True)
                     LOG.debug(response)
-                    self.update_alias(
-                        self._context.environment,
-                        'For the {} stage'.format(self._context.environment))
                 except Exception:
                     LOG.exception('unable to update zip file')
+        self.update_alias(
+            self._context.environment,
+            'For the {} stage'.format(self._context.environment))
         self.add_log_retention_policy()
 
     def update_configuration(self):

--- a/tests/unit/foobar/kappa-new-alias.yml
+++ b/tests/unit/foobar/kappa-new-alias.yml
@@ -2,13 +2,9 @@
 name: kappa-simple
 environments:
   dev:
-    profile: foobar
-    region: us-west-2
-    policy:
-      resources:
-        - arn: arn:aws:logs:*:*:*
-          actions:
-          - "*"
+    region: us-east-1
+  new-alias:
+    region: us-east-1
 lambda:
   description: Foo the Bar
   handler: simple.handler

--- a/tests/unit/responses/deploy/lambda.UpdateAlias_1.json
+++ b/tests/unit/responses/deploy/lambda.UpdateAlias_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Alias not found: arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:new-alias",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {
+            "RequestId": "31a8f673-fc87-11e6-9419-57c1d3a964b1",
+            "HTTPStatusCode": 404,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:46 GMT",
+                "x-amzn-errortype": "ResourceNotFoundException",
+                "x-amzn-requestid": "31a8f673-fc87-11e6-9419-57c1d3a964b1",
+                "content-length": "114",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.CreatePolicyVersion_1.json
+++ b/tests/unit/responses/deploy_update/iam.CreatePolicyVersion_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 403,
+    "data": {
+        "Error": {
+            "Type": "Sender",
+            "Code": "AccessDenied",
+            "Message": "User: arn:aws:iam::1234567890:user/Foo is not authorized to perform: iam:CreatePolicyVersion on resource: policy arn:aws:iam::1234567890:policy/kappa/kappa-simple_new-alias"
+        },
+        "ResponseMetadata": {
+            "RequestId": "3097d469-fc87-11e6-973d-55bc4e8fa5df",
+            "HTTPStatusCode": 403,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3097d469-fc87-11e6-973d-55bc4e8fa5df",
+                "content-type": "text/xml",
+                "content-length": "421",
+                "date": "Mon, 27 Feb 2017 00:53:44 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.CreatePolicy_1.json
+++ b/tests/unit/responses/deploy_update/iam.CreatePolicy_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policy": {
+            "PolicyName": "kappa-simple_dev",
+            "PolicyId": "ANPAI7F5OQ3EKQ6IGG5II",
+            "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_dev",
+            "Path": "/kappa/",
+            "DefaultVersionId": "v1",
+            "AttachmentCount": 0,
+            "IsAttachable": true,
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 27,
+                "hour": 0,
+                "minute": 53,
+                "second": 34,
+                "microsecond": 847000
+            },
+            "UpdateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 27,
+                "hour": 0,
+                "minute": 53,
+                "second": 34,
+                "microsecond": 847000
+            }
+        },
+        "ResponseMetadata": {
+            "RequestId": "2aaf3a0f-fc87-11e6-ac7e-955189028374",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2aaf3a0f-fc87-11e6-ac7e-955189028374",
+                "content-type": "text/xml",
+                "content-length": "716",
+                "date": "Mon, 27 Feb 2017 00:53:34 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.GetRole_1.json
+++ b/tests/unit/responses/deploy_update/iam.GetRole_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "Role": {
+            "Path": "/kappa/",
+            "RoleName": "kappa-simple_dev",
+            "RoleId": "AROAI2N2VJO5C2CC7ZWHI",
+            "Arn": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 5,
+                "hour": 1,
+                "minute": 22,
+                "second": 18,
+                "microsecond": 0
+            },
+            "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2ad33d8e-fc87-11e6-a59a-ebdf573605c2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2ad33d8e-fc87-11e6-a59a-ebdf573605c2",
+                "content-type": "text/xml",
+                "content-length": "759",
+                "date": "Mon, 27 Feb 2017 00:53:34 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.GetRole_2.json
+++ b/tests/unit/responses/deploy_update/iam.GetRole_2.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "Role": {
+            "Path": "/kappa/",
+            "RoleName": "kappa-simple_dev",
+            "RoleId": "AROAI2N2VJO5C2CC7ZWHI",
+            "Arn": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 5,
+                "hour": 1,
+                "minute": 22,
+                "second": 18,
+                "microsecond": 0
+            },
+            "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2b054958-fc87-11e6-a59a-ebdf573605c2",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2b054958-fc87-11e6-a59a-ebdf573605c2",
+                "content-type": "text/xml",
+                "content-length": "759",
+                "date": "Mon, 27 Feb 2017 00:53:35 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.GetRole_3.json
+++ b/tests/unit/responses/deploy_update/iam.GetRole_3.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "Role": {
+            "Path": "/kappa/",
+            "RoleName": "kappa-simple_new-alias",
+            "RoleId": "AROAJE47O4SSWQYBX73VQ",
+            "Arn": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 26,
+                "hour": 18,
+                "minute": 9,
+                "second": 22,
+                "microsecond": 0
+            },
+            "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D"
+        },
+        "ResponseMetadata": {
+            "RequestId": "30eb99e3-fc87-11e6-a03c-7b2455a28d8d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "30eb99e3-fc87-11e6-a03c-7b2455a28d8d",
+                "content-type": "text/xml",
+                "content-length": "771",
+                "date": "Mon, 27 Feb 2017 00:53:44 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.GetRole_4.json
+++ b/tests/unit/responses/deploy_update/iam.GetRole_4.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "Role": {
+            "Path": "/kappa/",
+            "RoleName": "kappa-simple_new-alias",
+            "RoleId": "AROAJE47O4SSWQYBX73VQ",
+            "Arn": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+            "CreateDate": {
+                "__class__": "datetime",
+                "year": 2017,
+                "month": 2,
+                "day": 26,
+                "hour": 18,
+                "minute": 9,
+                "second": 22,
+                "microsecond": 0
+            },
+            "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22lambda.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D"
+        },
+        "ResponseMetadata": {
+            "RequestId": "3120b3da-fc87-11e6-a03c-7b2455a28d8d",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3120b3da-fc87-11e6-a03c-7b2455a28d8d",
+                "content-type": "text/xml",
+                "content-length": "771",
+                "date": "Mon, 27 Feb 2017 00:53:45 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.ListPolicies_1.json
+++ b/tests/unit/responses/deploy_update/iam.ListPolicies_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policies": [
+            {
+                "PolicyName": "kappa-simple_new-alias",
+                "PolicyId": "ANPAJID6TMBOEVMCUACH4",
+                "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_new-alias",
+                "Path": "/kappa/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 1,
+                "IsAttachable": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                },
+                "UpdateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "2aa66063-fc87-11e6-ac7e-955189028374",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2aa66063-fc87-11e6-ac7e-955189028374",
+                "content-type": "text/xml",
+                "content-length": "810",
+                "date": "Mon, 27 Feb 2017 00:53:34 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.ListPolicies_2.json
+++ b/tests/unit/responses/deploy_update/iam.ListPolicies_2.json
@@ -1,0 +1,77 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policies": [
+            {
+                "PolicyName": "kappa-simple_dev",
+                "PolicyId": "ANPAI7F5OQ3EKQ6IGG5II",
+                "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_dev",
+                "Path": "/kappa/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 0,
+                "IsAttachable": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 0,
+                    "minute": 53,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "UpdateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 0,
+                    "minute": 53,
+                    "second": 34,
+                    "microsecond": 0
+                }
+            },
+            {
+                "PolicyName": "kappa-simple_new-alias",
+                "PolicyId": "ANPAJID6TMBOEVMCUACH4",
+                "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_new-alias",
+                "Path": "/kappa/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 1,
+                "IsAttachable": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                },
+                "UpdateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "307c850e-fc87-11e6-973d-55bc4e8fa5df",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "307c850e-fc87-11e6-973d-55bc4e8fa5df",
+                "content-type": "text/xml",
+                "content-length": "1289",
+                "date": "Mon, 27 Feb 2017 00:53:43 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.ListPolicies_3.json
+++ b/tests/unit/responses/deploy_update/iam.ListPolicies_3.json
@@ -1,0 +1,77 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policies": [
+            {
+                "PolicyName": "kappa-simple_dev",
+                "PolicyId": "ANPAI7F5OQ3EKQ6IGG5II",
+                "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_dev",
+                "Path": "/kappa/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 0,
+                "IsAttachable": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 0,
+                    "minute": 53,
+                    "second": 34,
+                    "microsecond": 0
+                },
+                "UpdateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 27,
+                    "hour": 0,
+                    "minute": 53,
+                    "second": 34,
+                    "microsecond": 0
+                }
+            },
+            {
+                "PolicyName": "kappa-simple_new-alias",
+                "PolicyId": "ANPAJID6TMBOEVMCUACH4",
+                "Arn": "arn:aws:iam::123456789012:policy/kappa/kappa-simple_new-alias",
+                "Path": "/kappa/",
+                "DefaultVersionId": "v1",
+                "AttachmentCount": 1,
+                "IsAttachable": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                },
+                "UpdateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "308585cb-fc87-11e6-973d-55bc4e8fa5df",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "308585cb-fc87-11e6-973d-55bc4e8fa5df",
+                "content-type": "text/xml",
+                "content-length": "1289",
+                "date": "Mon, 27 Feb 2017 00:53:44 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/iam.ListPolicyVersions_1.json
+++ b/tests/unit/responses/deploy_update/iam.ListPolicyVersions_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200,
+    "data": {
+        "Versions": [
+            {
+                "VersionId": "v1",
+                "IsDefaultVersion": true,
+                "CreateDate": {
+                    "__class__": "datetime",
+                    "year": 2017,
+                    "month": 2,
+                    "day": 26,
+                    "hour": 18,
+                    "minute": 9,
+                    "second": 22,
+                    "microsecond": 0
+                }
+            }
+        ],
+        "IsTruncated": false,
+        "ResponseMetadata": {
+            "RequestId": "308f49dc-fc87-11e6-973d-55bc4e8fa5df",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "308f49dc-fc87-11e6-973d-55bc4e8fa5df",
+                "content-type": "text/xml",
+                "content-length": "512",
+                "date": "Mon, 27 Feb 2017 00:53:44 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.CreateAlias_1.json
+++ b/tests/unit/responses/deploy_update/lambda.CreateAlias_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "2b64ce78-fc87-11e6-b186-2998b89cd8b5",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:35 GMT",
+                "x-amzn-requestid": "2b64ce78-fc87-11e6-b186-2998b89cd8b5",
+                "content-length": "143",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "AliasArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:dev",
+        "Name": "dev",
+        "FunctionVersion": "9",
+        "Description": "For stage dev"
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.CreateAlias_2.json
+++ b/tests/unit/responses/deploy_update/lambda.CreateAlias_2.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "31b2e1c7-fc87-11e6-a1eb-81b8fcdae6b1",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:46 GMT",
+                "x-amzn-requestid": "31b2e1c7-fc87-11e6-a1eb-81b8fcdae6b1",
+                "content-length": "166",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "AliasArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:new-alias",
+        "Name": "new-alias",
+        "FunctionVersion": "10",
+        "Description": "For the new-alias stage"
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.CreateFunction_1.json
+++ b/tests/unit/responses/deploy_update/lambda.CreateFunction_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "2b0f5bf9-fc87-11e6-999f-21eb225d97d3",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:35 GMT",
+                "x-amzn-requestid": "2b0f5bf9-fc87-11e6-999f-21eb225d97d3",
+                "content-length": "488",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "kappa-simple",
+        "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple",
+        "Runtime": "python2.7",
+        "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+        "Handler": "simple.handler",
+        "CodeSize": 983,
+        "Description": "Foo the Bar",
+        "Timeout": 3,
+        "MemorySize": 256,
+        "LastModified": "2017-02-27T00:53:35.518+0000",
+        "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+        "Version": "9"
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.GetFunction_1.json
+++ b/tests/unit/responses/deploy_update/lambda.GetFunction_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Function not found: arn:aws:lambda:us-east-1:123456789012:function:kappa-simple",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {
+            "RequestId": "2afb36fc-fc87-11e6-bb80-a72fae70ea37",
+            "HTTPStatusCode": 404,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:35 GMT",
+                "x-amzn-errortype": "ResourceNotFoundException",
+                "x-amzn-requestid": "2afb36fc-fc87-11e6-bb80-a72fae70ea37",
+                "content-length": "107",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.GetFunction_2.json
+++ b/tests/unit/responses/deploy_update/lambda.GetFunction_2.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "31189d72-fc87-11e6-ba18-05551768a17c",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:44 GMT",
+                "x-amzn-requestid": "31189d72-fc87-11e6-ba18-05551768a17c",
+                "content-length": "1615",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "Configuration": {
+            "FunctionName": "kappa-simple",
+            "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple",
+            "Runtime": "python2.7",
+            "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+            "Handler": "simple.handler",
+            "CodeSize": 983,
+            "Description": "Foo the Bar",
+            "Timeout": 3,
+            "MemorySize": 256,
+            "LastModified": "2017-02-27T00:53:35.518+0000",
+            "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+            "Version": "$LATEST"
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.ListVersionsByFunction_1.json
+++ b/tests/unit/responses/deploy_update/lambda.ListVersionsByFunction_1.json
@@ -1,0 +1,47 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "2b5dc9cd-fc87-11e6-91a1-99068d55265c",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:35 GMT",
+                "x-amzn-requestid": "2b5dc9cd-fc87-11e6-91a1-99068d55265c",
+                "content-length": "1026",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "Versions": [
+            {
+                "FunctionName": "kappa-simple",
+                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:$LATEST",
+                "Runtime": "python2.7",
+                "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+                "Handler": "simple.handler",
+                "CodeSize": 983,
+                "Description": "Foo the Bar",
+                "Timeout": 3,
+                "MemorySize": 256,
+                "LastModified": "2017-02-27T00:53:35.518+0000",
+                "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+                "Version": "$LATEST"
+            },
+            {
+                "FunctionName": "kappa-simple",
+                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:9",
+                "Runtime": "python2.7",
+                "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+                "Handler": "simple.handler",
+                "CodeSize": 983,
+                "Description": "Foo the Bar",
+                "Timeout": 3,
+                "MemorySize": 256,
+                "LastModified": "2017-02-27T00:53:35.518+0000",
+                "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+                "Version": "9"
+            }
+        ]
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.ListVersionsByFunction_2.json
+++ b/tests/unit/responses/deploy_update/lambda.ListVersionsByFunction_2.json
@@ -1,0 +1,61 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "319ff67a-fc87-11e6-91b3-198642eef327",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:46 GMT",
+                "x-amzn-requestid": "319ff67a-fc87-11e6-91b3-198642eef327",
+                "content-length": "1531",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "Versions": [
+            {
+                "FunctionName": "kappa-simple",
+                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:$LATEST",
+                "Runtime": "python2.7",
+                "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+                "Handler": "simple.handler",
+                "CodeSize": 983,
+                "Description": "Foo the Bar",
+                "Timeout": 3,
+                "MemorySize": 256,
+                "LastModified": "2017-02-27T00:53:46.035+0000",
+                "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+                "Version": "$LATEST"
+            },
+            {
+                "FunctionName": "kappa-simple",
+                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:9",
+                "Runtime": "python2.7",
+                "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_dev",
+                "Handler": "simple.handler",
+                "CodeSize": 983,
+                "Description": "Foo the Bar",
+                "Timeout": 3,
+                "MemorySize": 256,
+                "LastModified": "2017-02-27T00:53:35.518+0000",
+                "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+                "Version": "9"
+            },
+            {
+                "FunctionName": "kappa-simple",
+                "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:10",
+                "Runtime": "python2.7",
+                "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+                "Handler": "simple.handler",
+                "CodeSize": 983,
+                "Description": "Foo the Bar",
+                "Timeout": 3,
+                "MemorySize": 256,
+                "LastModified": "2017-02-27T00:53:46.035+0000",
+                "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+                "Version": "10"
+            }
+        ]
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.UpdateAlias_1.json
+++ b/tests/unit/responses/deploy_update/lambda.UpdateAlias_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Alias not found: arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:new-alias",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {
+            "RequestId": "31a8f673-fc87-11e6-9419-57c1d3a964b1",
+            "HTTPStatusCode": 404,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:46 GMT",
+                "x-amzn-errortype": "ResourceNotFoundException",
+                "x-amzn-requestid": "31a8f673-fc87-11e6-9419-57c1d3a964b1",
+                "content-length": "114",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.UpdateFunctionCode_1.json
+++ b/tests/unit/responses/deploy_update/lambda.UpdateFunctionCode_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "31535ca1-fc87-11e6-893d-1b9e1b26aaa0",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:45 GMT",
+                "x-amzn-requestid": "31535ca1-fc87-11e6-893d-1b9e1b26aaa0",
+                "content-length": "498",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "kappa-simple",
+        "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple:10",
+        "Runtime": "python2.7",
+        "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+        "Handler": "simple.handler",
+        "CodeSize": 983,
+        "Description": "Foo the Bar",
+        "Timeout": 3,
+        "MemorySize": 256,
+        "LastModified": "2017-02-27T00:53:46.035+0000",
+        "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+        "Version": "10"
+    }
+}

--- a/tests/unit/responses/deploy_update/lambda.UpdateFunctionConfiguration_1.json
+++ b/tests/unit/responses/deploy_update/lambda.UpdateFunctionConfiguration_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "312a50a8-fc87-11e6-93f0-331d739638da",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/json",
+                "date": "Mon, 27 Feb 2017 00:53:45 GMT",
+                "x-amzn-requestid": "312a50a8-fc87-11e6-93f0-331d739638da",
+                "content-length": "500",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "kappa-simple",
+        "FunctionArn": "arn:aws:lambda:us-east-1:123456789012:function:kappa-simple",
+        "Runtime": "python2.7",
+        "Role": "arn:aws:iam::123456789012:role/kappa/kappa-simple_new-alias",
+        "Handler": "simple.handler",
+        "CodeSize": 983,
+        "Description": "Foo the Bar",
+        "Timeout": 3,
+        "MemorySize": 256,
+        "LastModified": "2017-02-27T00:53:45.710+0000",
+        "CodeSha256": "xDpYBz0GtoyDB9ABWCTjH+e+oD+gQfe0fy5CEmqvbEc=",
+        "Version": "$LATEST"
+    }
+}

--- a/tests/unit/test_deploy_update.py
+++ b/tests/unit/test_deploy_update.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 Mitch Garnaat http://garnaat.org/
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import unittest
+import os
+import shutil
+
+import mock
+import placebo
+
+import kappa.context
+import kappa.awsclient
+
+
+class TestDeployUpdate(unittest.TestCase):
+
+    def setUp(self):
+        self.environ = {}
+        self.environ_patch = mock.patch('os.environ', self.environ)
+        self.environ_patch.start()
+        self.prj_path = os.path.join(os.path.dirname(__file__), 'foobar')
+        cache_file = os.path.join(self.prj_path, '.kappa')
+        if os.path.exists(cache_file):
+            shutil.rmtree(cache_file)
+        self.data_path = os.path.join(os.path.dirname(__file__), 'responses')
+        self.data_path = os.path.join(self.data_path, 'deploy_update')
+        self.environ['AWS_ACCESS_KEY_ID'] = 'foo'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'bar'
+        self.session = kappa.awsclient.create_session(None, 'us-east-1')
+
+    def tearDown(self):
+        pass
+
+    def test_deploy_update_no_alias(self):
+        pill = placebo.attach(self.session, self.data_path)
+        pill.playback()
+        os.chdir(self.prj_path)
+        cfg_filepath = os.path.join(self.prj_path, 'kappa-new-alias.yml')
+        cfg_fp = open(cfg_filepath)
+        ctx = kappa.context.Context(cfg_fp, 'dev')
+        ctx.deploy()
+
+        cfg_fp = open(cfg_filepath)
+        ctx = kappa.context.Context(cfg_fp, 'new-alias')
+        ctx.deploy()


### PR DESCRIPTION
 * Create alias on update if it does not exist
 * Update alias always (even if there is no code change, alias might change version)
 * Adding a bunch of placebo responses for new behaviour (old tests still work with old responses)

Tested on Python `2.7.13` and `3.6.0`