### PR TITLE
Make setup.py parseable on Python 3 with LANG=C (or unset).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 def open_file(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname))
+    return open(os.path.join(os.path.dirname(__file__), fname), "rb")
 
 
 def run_setup():
@@ -19,7 +19,7 @@ def run_setup():
         name='kappa',
         version=__version__,
         description='A CLI tool for AWS Lambda developers',
-        long_description=open_file('README.rst').read(),
+        long_description=open_file('README.rst').read().decode("utf-8"),
         url='https://github.com/garnaat/kappa',
         author='Mitch Garnaat',
         author_email='mitch@garnaat.com',
@@ -31,7 +31,7 @@ def run_setup():
             [console_scripts]
             kappa=kappa.scripts.cli:cli
         """,
-        install_requires=open_file('requirements.txt').readlines(),
+        install_requires=open_file('requirements.txt').read().decode("utf-8").split(),
         test_suite='tests',
         include_package_data=True,
         zip_safe=True,


### PR DESCRIPTION
Running `pip install kappa` in a barebones environment (e.g. AmazonLinux Docker container), or anything where LANG is not UTF-8 (e.g. `en_US.UTF-8`) fails without this patch. This is because `setup.py` runs `open_file("README.rst")`, which in turn opens the file in text mode. On Python 3, this uses the ASCII codec, but `README.rst` contains UTF-8 characters.

This patch forcibly parses `README.rst` (and `requirements.txt`) as UTF-8 regardless of the user's codec.