### PR TITLE
Add encoding for open_file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 def open_file(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname))
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8')
 
 
 def run_setup():


### PR DESCRIPTION
This is because ```open``` function will use system encoding which is got by ```locale.getpreferredencoding(False)```  according to [python documentation](https://docs.python.org/3/library/functions.html#open). This may cause installation failure in non UTF-8 encoding systems.

At least, ```UnicodeDecodeError: 'gbk' codec can't decode byte 0x80 in position 2347: illegal multibyte sequence``` will be raised when setup in my system with encoding ```cp936```.