### PR TITLE
Fix s3 event creation using lambda arn 

### DIFF
--- a/kappa/__init__.py
+++ b/kappa/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.7.1'
+__version__ = '0.7.0'

--- a/kappa/__init__.py
+++ b/kappa/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/kappa/event_source/s3.py
+++ b/kappa/event_source/s3.py
@@ -56,14 +56,14 @@ class S3EventSource(kappa.event_source.base.EventSource):
         existingPermission={}
         try:
             response = self._lambda.call('get_policy',
-                                     FunctionName=function.name)
+                                     FunctionName=function.arn)
             existingPermission = self.arn in str(response['Policy'])
         except Exception:
             LOG.debug('S3 event source permission not available')
 
         if not existingPermission:
             response = self._lambda.call('add_permission',
-                                         FunctionName=function.name,
+                                         FunctionName=function.arn,
                                          StatementId=str(uuid.uuid4()),
                                          Action='lambda:InvokeFunction',
                                          Principal='s3.amazonaws.com',


### PR DESCRIPTION
On lambda policy lookup/update pass function ARN as FunctionName  …
AWS expects ARN as FunctionName parameter on both AddPermission
and GetPolicy calls. Using function.name precludes from having
different values between function.arn and function.name, lest
updates won't work.

http://docs.aws.amazon.com/lambda/latest/dg/API_GetPolicy.html
http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html

Co-authored-by: Ilya Sukhanov <ilya@sukhanov.net>