### PR TITLE
Fixed Python 3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from io import open
 from kappa import __version__
 import os
 
@@ -11,7 +12,7 @@ except ImportError:
 
 
 def open_file(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname))
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8')
 
 
 def run_setup():


### PR DESCRIPTION
Otherwise, the build fails with an encoding error due to the default locale being ASCII on the Debian builders, not UTF-8. Regardless, this is the recommended approach for writing a setup.py which supports both Python 2 and Python 3.

Similar problem:
[pytest-dev/pytest-mock#107](https://github.com/pytest-dev/pytest-mock/pull/107)